### PR TITLE
fix: notes for 1.8 (zero) has weird padding

### DIFF
--- a/downloads/expandedworlds.html
+++ b/downloads/expandedworlds.html
@@ -221,9 +221,9 @@
 					<li>1.8 (Zero)</li>
 				</h4>
 				<ul id="1.8-64">
-					<div id="1.8-note"><ul>Note from author:
+					<div id="1.8-note">Note from author:
 						Very buggy, has log spam which can rapidly decrease FPS and can cause disk usage to rise drastically, has a bug at 2^35 which causes stripes of chunks to not load every power of 2, Chunk overwrite limit causes chunk and entity relocation spam, highly unstable. Player will be affected.
-						<li>v2 - Most issues are fixed, log spam is fixed</li>
+						<ul><li>v2 - Most issues are fixed, log spam is fixed</li>
 						<li>v3 - Fixes 2^35 bug, Slowfalling still exists (due to server thread becoming overloaded)</li></ul></div>
 					<li><a href="../mods/64bit/release/1.8/minecraft-1.8-64bit-v1-zero.zip">v1.0</a></li>
 					<li><a href="../mods/64bit/release/1.8/minecraft-1.8-64bit-v2-zero.zip">v2.0</a></li>


### PR DESCRIPTION
- placed the note outside the `<ul>`
- beautified the code from https://beautifier.io as a bonus

before
![image](https://github.com/CursedCreationsTeam/cursedcreationsteam.github.io/assets/54856929/7ff3eda6-14f8-4621-b8d6-c16c6156fa9e)

after
![image](https://github.com/CursedCreationsTeam/cursedcreationsteam.github.io/assets/54856929/c269a038-c218-423f-bf2d-f520463a23e7)
